### PR TITLE
sender stats

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,29 +1,23 @@
 cmake_minimum_required(VERSION 3.16)
 
+project(multicast_streaming_service)
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-include(${CMAKE_SOURCE_DIR}/ProjectConfig.cmake)
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Release)
-endif()
-
-set(CMAKE_CXX_FLAGS "-O3")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3")
-
-project(multicast_streaming_service)
-
 find_package(OpenCV REQUIRED)
+find_package(Threads REQUIRED)
 
-include_directories("${CMAKE_SOURCE_DIR}/multicast_core/include/multicast_core_bits")
-include_directories("${CMAKE_SOURCE_DIR}/pybindings")
+include_directories(
+    "${CMAKE_SOURCE_DIR}/multicast_core/include/multicast_core_bits"
+    "${CMAKE_SOURCE_DIR}/pybindings"
+)
 
-file (GLOB SRC_FILES "multicast_core/src/*.cpp")
-file (GLOB HEADER_FILES "multicast_core/include/multicast_core_bits/*.h")
-file (GLOB PYBINDINGS_FILES "pybindings/*.cpp" "pybindings/*.h")
+file(GLOB SRC_FILES "multicast_core/src/*.cpp")
+file(GLOB HEADER_FILES "multicast_core/include/multicast_core_bits/*.h")
+file(GLOB PYBINDINGS_FILES "pybindings/*.cpp")
 
 include(FetchContent)
 FetchContent_Declare(
@@ -33,15 +27,16 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11)
 
-pybind11_add_module(multicast_core 
-	${SRC_FILES}
-	${HEADER_FILES}
-	${PYBINDINGS_FILES}
-)
+add_library(multicast_core SHARED ${SRC_FILES} ${PYBINDINGS_FILES})
+target_link_libraries(multicast_core PRIVATE ${OpenCV_LIBS} Threads::Threads)
 
-target_link_libraries(multicast_core PUBLIC ${OpenCV_LIBS})
+if(WIN32)
+    target_link_libraries(multicast_core PRIVATE ws2_32)
+endif()
 
-install(TARGETS multicast_core
-  COMPONENT python
-  LIBRARY DESTINATION "${PYTHON_LIB_INSTALL_DIR}"
+pybind11_add_module(multicast_core_pybind ${PYBINDINGS_FILES})
+target_link_libraries(multicast_core_pybind PRIVATE multicast_core)
+
+install(TARGETS multicast_core_pybind
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/python"
 )

--- a/multicast_core/src/sender.cpp
+++ b/multicast_core/src/sender.cpp
@@ -9,53 +9,111 @@
 
 namespace MulticastLib {
 
-Sender::Sender(const std::string& multicastIP, int port)
-    : multicastIP_(multicastIP), port_(port), isStreaming_(false), sockfd_(-1) {}
+Sender::Sender(const std::string& multicastAddress, int port) 
+    : multicastIP_(multicastAddress), port_(port), sockfd_(INVALID_SOCKET), 
+      heartbeatSock_(INVALID_SOCKET), isStreaming_(false) {
+    WSADATA wsaData;
+    WSAStartup(MAKEWORD(2, 2), &wsaData);
+}
 
 Sender::~Sender() {
-    if (sockfd_ != -1) close(sockfd_);
-    if (streamThread_.joinable()) streamThread_.join();
-    if (camera_.isOpened()) camera_.release();
+    stopStream();
+    WSACleanup();
 }
 
 bool Sender::setupSocket() {
-    // Создание и конфигурация сокета
-    sockfd_ = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sockfd_ < 0) {
-        std::cerr << "Failed to create socket" << std::endl;
+    // Multicast socket
+    sockfd_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sockfd_ == INVALID_SOCKET) {
+        std::cerr << "Failed to create socket: " << WSAGetLastError() << std::endl;
         return false;
     }
 
-    // time to live для мультикаст пакетов = 1 позволяет доставлять пакеты только локально
-    int ttl = 1;
-    if (setsockopt(sockfd_, IPPROTO_IP, IP_MULTICAST_TTL, &ttl, sizeof(ttl)) < 0) {
-        perror("setsockopt IP_MULTICAST_TTL failed");
+    // Heartbeat socket
+    heartbeatSock_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (heartbeatSock_ == INVALID_SOCKET) {
+        std::cerr << "Failed to create heartbeat socket: " << WSAGetLastError() << std::endl;
         return false;
     }
 
-    memset(&multicastAddr_, 0, sizeof(multicastAddr_));
+    // Bind heartbeat socket
+    sockaddr_in heartbeatAddr{};
+    heartbeatAddr.sin_family = AF_INET;
+    heartbeatAddr.sin_addr.s_addr = htonl(INADDR_ANY);
+    heartbeatAddr.sin_port = htons(port_ + 1);
+
+    if (bind(heartbeatSock_, (sockaddr*)&heartbeatAddr, sizeof(heartbeatAddr)) == SOCKET_ERROR) {
+        std::cerr << "Bind failed: " << WSAGetLastError() << std::endl;
+        return false;
+    }
+
+    // Configure multicast socket
     multicastAddr_.sin_family = AF_INET;
     multicastAddr_.sin_addr.s_addr = inet_addr(multicastIP_.c_str());
     multicastAddr_.sin_port = htons(port_);
+
+    int ttl = 1;
+    if (setsockopt(sockfd_, IPPROTO_IP, IP_MULTICAST_TTL, (char*)&ttl, sizeof(ttl)) == SOCKET_ERROR) {
+        std::cerr << "setsockopt failed: " << WSAGetLastError() << std::endl;
+        return false;
+    }
+
     return true;
 }
 
+void Sender::startHeartbeatServer() {
+    heartbeatThread_ = std::thread([this]() {
+        char buffer[1024];
+        sockaddr_in clientAddr{};
+        int addrLen = sizeof(clientAddr);
+
+        while (isStreaming_) {
+            int bytes = recvfrom(heartbeatSock_, buffer, sizeof(buffer), 0,
+                (sockaddr*)&clientAddr, &addrLen);
+
+            if (bytes > 0) {
+                char clientIP[INET_ADDRSTRLEN];
+                inet_ntop(AF_INET, &clientAddr.sin_addr, clientIP, INET_ADDRSTRLEN);
+
+                std::lock_guard<std::mutex> lock(clientsMutex_);
+                activeClients_[clientIP] = std::chrono::system_clock::now();
+                activeUsersCount_ = activeClients_.size();
+            }
+
+            // Cleanup every 5 seconds
+            std::this_thread::sleep_for(std::chrono::seconds(5));
+            cleanupInactiveClients();
+        }
+    });
+}
+
+void Sender::cleanupInactiveClients() {
+    auto now = std::chrono::system_clock::now();
+    std::lock_guard<std::mutex> lock(clientsMutex_);
+
+    for (auto it = activeClients_.begin(); it != activeClients_.end();) {
+        if (now - it->second > std::chrono::seconds(15)) {
+            it = activeClients_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    activeUsersCount_ = activeClients_.size();
+}
+
 bool Sender::startStream() {
-    // Начинает стрим
     if (isStreaming_) return false;
     if (!setupSocket()) return false;
 
-    // Включение камеры
-    camera_.open(0, cv::CAP_ANY);
+    camera_.open(0, cv::CAP_DSHOW);
     if (!camera_.isOpened()) {
-        std::cerr << "Failed to open camera_" << std::endl;
+        std::cerr << "Failed to open camera" << std::endl;
         return false;
     }
 
     isStreaming_ = true;
-
-    // Запуск потока для захвата и отправки видео
     streamThread_ = std::thread(&Sender::streamLoop, this);
+    startHeartbeatServer();
     return true;
 }
 

--- a/pybindings/sender.cpp
+++ b/pybindings/sender.cpp
@@ -14,7 +14,6 @@ void init_sender(py::module_& m) {
         .def(py::init<const std::string&, int>())
         .def("start_stream", &Sender::startStream)
         .def("stop_stream", &Sender::stopStream)
-        .def(
-            "get_preview_frame", [](Sender& self) { return matToNumpy(self.getPreviewFrame()); },
-            "Get last captured frame as numpy array");
+        .def("get_active_users", &Sender::getActiveUsers)
+        .def("get_preview_frame", [](Sender& self) { return matToNumpy(self.getPreviewFrame()); });
 }


### PR DESCRIPTION
Реализация подсчета пользователей:

Клиенты отправляют любые данные на порт port + 1 (например, пустой UDP-пакет).

Таймаут неактивности: 15 секунд.

Счетчик автоматически обновляется и доступен через get_active_users().